### PR TITLE
diff_is.t needs /tmp, so skip it on android

### DIFF
--- a/t/diff_is.t
+++ b/t/diff_is.t
@@ -1,8 +1,8 @@
 use Test::Base tests => 1;
 
 SKIP: {
-    if ($^O eq 'MSWin32') {
-        skip 'Win32 doesn\'t have /tmp', 1;
+    if ($^O eq 'MSWin32' || $^O eq 'android') {
+        skip "$^O doesn't have /tmp", 1;
     }
 
     unless (Test::Base->have_text_diff) {


### PR DESCRIPTION
Didn't remember I had filed https://github.com/ingydotnet/test-base-pm/issues/5 about this before, but oh well. Same as that, but in handy pull request format.
