### PR TITLE
Depend on Test::Stream (not released yet)

### DIFF
--- a/Meta
+++ b/Meta
@@ -31,6 +31,7 @@ test:
     Algorithm::Diff: 1.15
     ExtUtils::MakeMaker: 6.52
     Text::Diff: 0.35
+    Test::Stream: 1.301001
 
 recommends:
   Test::Deep: 0


### PR DESCRIPTION
Ingy,

This updates Test::Base to use Test::Stream. This patch will make it so Test::Base WILL NOT WORK without Test::Stream. Since Test::Stream is not in any stable cpan releases yet, you SHOULD NOT release this at the moment.