### PR TITLE
Requires Test::More >= 0.88

### DIFF
--- a/Meta
+++ b/Meta
@@ -25,6 +25,7 @@ requires:
   perl: 5.8.1
   Filter::Util::Call: 0
   Spiffy: 0.40
+  Test::More: 0.88
 
 test:
   requires:


### PR DESCRIPTION
I tried to install Test::Base on perl 5.8.5 and the
tests failed because

```
t/000-require-modules....You tried to run a test without a plan at t/000-require-modules.t line 9
```

I added Test::More 0.88 to Meta
